### PR TITLE
Adds support for Int64 values

### DIFF
--- a/EVReflection/pod/EVReflection.swift
+++ b/EVReflection/pod/EVReflection.swift
@@ -324,6 +324,8 @@ final public class EVReflection {
         }
 
         switch(theValue) {
+        case let longValue as Int64:
+            return NSNumber(long: CLong(longValue))
         case let intValue as Int:
             return NSNumber(int: CInt(intValue))
         case let doubleValue as Double:


### PR DESCRIPTION
Application would crash trying to convert a large Int to CInt -
case let intValue as Int:
     return NSNumber(int: CInt(intValue))
