### PR TITLE
Added EVReflection framework target with a shared scheme for carthage compatibility

### DIFF
--- a/EVReflection/EVReflection.xcodeproj/project.pbxproj
+++ b/EVReflection/EVReflection.xcodeproj/project.pbxproj
@@ -7,14 +7,18 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		7F07C5881AF10437000DF1F3 /* EVReflection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F07C5841AF10284000DF1F3 /* EVReflection.swift */; };
-		7F0E5E5A1AF4D94000A10E51 /* EVObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F0E5E591AF4D94000A10E51 /* EVObject.swift */; };
-		7F1BA5271B971CBF009F9DB8 /* EVExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F1BA5261B971CBF009F9DB8 /* EVExtensions.swift */; };
-		7F3E192A1B8526CA00A6E6C6 /* EVObjectDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F3E19291B8526CA00A6E6C6 /* EVObjectDescription.swift */; };
-		7F3E318D1BB909A1001E6788 /* EVReflection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F07C5841AF10284000DF1F3 /* EVReflection.swift */; };
-		7F3E318E1BB909A1001E6788 /* EVObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F0E5E591AF4D94000A10E51 /* EVObject.swift */; };
-		7F3E318F1BB909A1001E6788 /* EVObjectDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F3E19291B8526CA00A6E6C6 /* EVObjectDescription.swift */; };
-		7F3E31901BB909A1001E6788 /* EVExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F1BA5261B971CBF009F9DB8 /* EVExtensions.swift */; };
+		2DC8AA401C24215500FA6B8E /* EVReflection.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DC8AA3F1C24215500FA6B8E /* EVReflection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2DC8AA541C2421D600FA6B8E /* EVReflection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F07C5841AF10284000DF1F3 /* EVReflection.swift */; };
+		2DC8AA551C2421D600FA6B8E /* EVObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F0E5E591AF4D94000A10E51 /* EVObject.swift */; };
+		2DC8AA561C2421D600FA6B8E /* EVObjectDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F3E19291B8526CA00A6E6C6 /* EVObjectDescription.swift */; };
+		2DC8AA571C2421D600FA6B8E /* EVExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F1BA5261B971CBF009F9DB8 /* EVExtensions.swift */; };
+		2DC8AA581C2428A900FA6B8E /* EVReflection.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2DC8AA3D1C24215500FA6B8E /* EVReflection.framework */; };
+		2DC8AA661C242E0600FA6B8E /* EVReflectionOSX.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DC8AA651C242E0600FA6B8E /* EVReflectionOSX.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2DC8AA7C1C242ECC00FA6B8E /* EVReflection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F07C5841AF10284000DF1F3 /* EVReflection.swift */; };
+		2DC8AA7D1C242ECE00FA6B8E /* EVObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F0E5E591AF4D94000A10E51 /* EVObject.swift */; };
+		2DC8AA7E1C242ED000FA6B8E /* EVObjectDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F3E19291B8526CA00A6E6C6 /* EVObjectDescription.swift */; };
+		2DC8AA7F1C242ED200FA6B8E /* EVExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F1BA5261B971CBF009F9DB8 /* EVExtensions.swift */; };
+		2DC8AA801C242FAB00FA6B8E /* EVReflection.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2DC8AA631C242E0600FA6B8E /* EVReflection.framework */; };
 		7F3E31911BB909A7001E6788 /* TestObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F41ECA41B91F2E0003A2236 /* TestObjects.swift */; };
 		7F3E31921BB909A7001E6788 /* EVObjectDescriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F41ECA61B91F306003A2236 /* EVObjectDescriptionTests.swift */; };
 		7F3E31931BB909A7001E6788 /* EVReflectionJsonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F41ECA71B91F306003A2236 /* EVReflectionJsonTests.swift */; };
@@ -40,7 +44,30 @@
 		7F8818F91C04447100E17072 /* EVReflectionPropertyMappingTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F8818F81C04447100E17072 /* EVReflectionPropertyMappingTest.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		2DC8AA5C1C24291800FA6B8E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7F07C5551AF101A9000DF1F3 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2DC8AA3C1C24215500FA6B8E;
+			remoteInfo = EVReflection;
+		};
+		2DC8AA7A1C242E9100FA6B8E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7F07C5551AF101A9000DF1F3 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2DC8AA621C242E0600FA6B8E;
+			remoteInfo = "EVReflection OSX";
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
+		2DC8AA3D1C24215500FA6B8E /* EVReflection.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = EVReflection.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2DC8AA3F1C24215500FA6B8E /* EVReflection.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EVReflection.h; sourceTree = "<group>"; };
+		2DC8AA411C24215500FA6B8E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		2DC8AA631C242E0600FA6B8E /* EVReflection.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = EVReflection.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2DC8AA651C242E0600FA6B8E /* EVReflectionOSX.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EVReflectionOSX.h; sourceTree = "<group>"; };
+		2DC8AA671C242E0600FA6B8E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		7F0636B31AFF413900595461 /* .travis.yml */ = {isa = PBXFileReference; lastKnownFileType = text; path = .travis.yml; sourceTree = "<group>"; };
 		7F07C5721AF101A9000DF1F3 /* EVReflection iOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "EVReflection iOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7F07C5771AF101A9000DF1F3 /* ios-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "ios-Info.plist"; sourceTree = "<group>"; };
@@ -72,10 +99,25 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		2DC8AA391C24215500FA6B8E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2DC8AA5F1C242E0600FA6B8E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		7F07C56F1AF101A9000DF1F3 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2DC8AA581C2428A900FA6B8E /* EVReflection.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -83,12 +125,31 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2DC8AA801C242FAB00FA6B8E /* EVReflection.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		2DC8AA3E1C24215500FA6B8E /* EVReflection */ = {
+			isa = PBXGroup;
+			children = (
+				2DC8AA3F1C24215500FA6B8E /* EVReflection.h */,
+				2DC8AA411C24215500FA6B8E /* Info.plist */,
+			);
+			path = EVReflection;
+			sourceTree = "<group>";
+		};
+		2DC8AA641C242E0600FA6B8E /* EVReflectionOSX */ = {
+			isa = PBXGroup;
+			children = (
+				2DC8AA651C242E0600FA6B8E /* EVReflectionOSX.h */,
+				2DC8AA671C242E0600FA6B8E /* Info.plist */,
+			);
+			path = EVReflectionOSX;
+			sourceTree = "<group>";
+		};
 		7F07C5541AF101A9000DF1F3 = {
 			isa = PBXGroup;
 			children = (
@@ -100,6 +161,8 @@
 				7FFCCC361BB440F400EE9312 /* coverage.png */,
 				7F07C5831AF10284000DF1F3 /* pod */,
 				7F07C5751AF101A9000DF1F3 /* EVReflectionTests */,
+				2DC8AA3E1C24215500FA6B8E /* EVReflection */,
+				2DC8AA641C242E0600FA6B8E /* EVReflectionOSX */,
 				7F07C55E1AF101A9000DF1F3 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -109,6 +172,8 @@
 			children = (
 				7F07C5721AF101A9000DF1F3 /* EVReflection iOS Tests.xctest */,
 				7F3E31851BB9095C001E6788 /* EVReflection OSX Tests.xctest */,
+				2DC8AA3D1C24215500FA6B8E /* EVReflection.framework */,
+				2DC8AA631C242E0600FA6B8E /* EVReflection.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -165,7 +230,62 @@
 		};
 /* End PBXGroup section */
 
+/* Begin PBXHeadersBuildPhase section */
+		2DC8AA3A1C24215500FA6B8E /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2DC8AA401C24215500FA6B8E /* EVReflection.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2DC8AA601C242E0600FA6B8E /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2DC8AA661C242E0600FA6B8E /* EVReflectionOSX.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
 /* Begin PBXNativeTarget section */
+		2DC8AA3C1C24215500FA6B8E /* EVReflection iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2DC8AA521C24215500FA6B8E /* Build configuration list for PBXNativeTarget "EVReflection iOS" */;
+			buildPhases = (
+				2DC8AA381C24215500FA6B8E /* Sources */,
+				2DC8AA391C24215500FA6B8E /* Frameworks */,
+				2DC8AA3A1C24215500FA6B8E /* Headers */,
+				2DC8AA3B1C24215500FA6B8E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "EVReflection iOS";
+			productName = EVReflection;
+			productReference = 2DC8AA3D1C24215500FA6B8E /* EVReflection.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		2DC8AA621C242E0600FA6B8E /* EVReflection OSX */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2DC8AA741C242E0600FA6B8E /* Build configuration list for PBXNativeTarget "EVReflection OSX" */;
+			buildPhases = (
+				2DC8AA5E1C242E0600FA6B8E /* Sources */,
+				2DC8AA5F1C242E0600FA6B8E /* Frameworks */,
+				2DC8AA601C242E0600FA6B8E /* Headers */,
+				2DC8AA611C242E0600FA6B8E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "EVReflection OSX";
+			productName = EVReflectionOSX;
+			productReference = 2DC8AA631C242E0600FA6B8E /* EVReflection.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		7F07C5711AF101A9000DF1F3 /* EVReflection iOS Tests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 7F07C57F1AF101A9000DF1F3 /* Build configuration list for PBXNativeTarget "EVReflection iOS Tests" */;
@@ -177,6 +297,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				2DC8AA5D1C24291800FA6B8E /* PBXTargetDependency */,
 			);
 			name = "EVReflection iOS Tests";
 			productName = EVReflectionTests;
@@ -194,6 +315,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				2DC8AA7B1C242E9100FA6B8E /* PBXTargetDependency */,
 			);
 			name = "EVReflection OSX Tests";
 			productName = "EVReflection OSX Tests";
@@ -206,10 +328,16 @@
 		7F07C5551AF101A9000DF1F3 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0700;
+				LastSwiftUpdateCheck = 0720;
 				LastUpgradeCheck = 0710;
 				ORGANIZATIONNAME = evict;
 				TargetAttributes = {
+					2DC8AA3C1C24215500FA6B8E = {
+						CreatedOnToolsVersion = 7.2;
+					};
+					2DC8AA621C242E0600FA6B8E = {
+						CreatedOnToolsVersion = 7.2;
+					};
 					7F07C5711AF101A9000DF1F3 = {
 						CreatedOnToolsVersion = 6.3.1;
 						TestTargetID = 7F07C55C1AF101A9000DF1F3;
@@ -234,11 +362,27 @@
 			targets = (
 				7F07C5711AF101A9000DF1F3 /* EVReflection iOS Tests */,
 				7F3E31841BB9095C001E6788 /* EVReflection OSX Tests */,
+				2DC8AA3C1C24215500FA6B8E /* EVReflection iOS */,
+				2DC8AA621C242E0600FA6B8E /* EVReflection OSX */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		2DC8AA3B1C24215500FA6B8E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2DC8AA611C242E0600FA6B8E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		7F07C5701AF101A9000DF1F3 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -256,23 +400,41 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		2DC8AA381C24215500FA6B8E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2DC8AA541C2421D600FA6B8E /* EVReflection.swift in Sources */,
+				2DC8AA551C2421D600FA6B8E /* EVObject.swift in Sources */,
+				2DC8AA561C2421D600FA6B8E /* EVObjectDescription.swift in Sources */,
+				2DC8AA571C2421D600FA6B8E /* EVExtensions.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2DC8AA5E1C242E0600FA6B8E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2DC8AA7F1C242ED200FA6B8E /* EVExtensions.swift in Sources */,
+				2DC8AA7C1C242ECC00FA6B8E /* EVReflection.swift in Sources */,
+				2DC8AA7D1C242ECE00FA6B8E /* EVObject.swift in Sources */,
+				2DC8AA7E1C242ED000FA6B8E /* EVObjectDescription.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		7F07C56E1AF101A9000DF1F3 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7F3E192A1B8526CA00A6E6C6 /* EVObjectDescription.swift in Sources */,
 				7F41ECB21B91F306003A2236 /* EVReflectionWorkaroundsTests.swift in Sources */,
-				7F07C5881AF10437000DF1F3 /* EVReflection.swift in Sources */,
 				7F59F9DD1C079A7300C14CF9 /* EVReflectionNumbersTests.swift in Sources */,
 				7F41ECB01B91F306003A2236 /* ProfilePhotoUrlListTest.swift in Sources */,
-				7F1BA5271B971CBF009F9DB8 /* EVExtensions.swift in Sources */,
 				7F59F9DB1C07999300C14CF9 /* EVReflectionEVObjectTests.swift in Sources */,
 				7F8818F91C04447100E17072 /* EVReflectionPropertyMappingTest.swift in Sources */,
 				7F41ECA51B91F2E0003A2236 /* TestObjects.swift in Sources */,
 				7F41ECB31B91F306003A2236 /* EVReflectionWorkaroundSwiftGenericsTests.swift in Sources */,
 				7F59F9D91C07986200C14CF9 /* EVReflectionAssociatedTests.swift in Sources */,
 				7F41ECAD1B91F306003A2236 /* EVObjectDescriptionTests.swift in Sources */,
-				7F0E5E5A1AF4D94000A10E51 /* EVObject.swift in Sources */,
 				7F41ECB11B91F306003A2236 /* WorkaroundEnumTest.swift in Sources */,
 				7F59F9DF1C09BFB900C14CF9 /* EVRelfectionEnheritanceTests.swift in Sources */,
 				7F7BBC661C009EE90046F05E /* EVReflectionMappingTest.swift in Sources */,
@@ -287,23 +449,128 @@
 			files = (
 				7F3E31961BB909A7001E6788 /* EVReflectionWorkaroundsTests.swift in Sources */,
 				7F3E31971BB909A7001E6788 /* EVReflectionWorkaroundSwiftGenericsTests.swift in Sources */,
-				7F3E31901BB909A1001E6788 /* EVExtensions.swift in Sources */,
 				7F3E31931BB909A7001E6788 /* EVReflectionJsonTests.swift in Sources */,
 				7F3E31981BB909B1001E6788 /* WorkaroundEnumTest.swift in Sources */,
 				7F7BBC671C00A22B0046F05E /* EVReflectionMappingTest.swift in Sources */,
 				7F3E31911BB909A7001E6788 /* TestObjects.swift in Sources */,
-				7F3E318D1BB909A1001E6788 /* EVReflection.swift in Sources */,
-				7F3E318F1BB909A1001E6788 /* EVObjectDescription.swift in Sources */,
 				7F3E31951BB909A7001E6788 /* ProfilePhotoUrlListTest.swift in Sources */,
 				7F3E31941BB909A7001E6788 /* EVReflectionTests.swift in Sources */,
 				7F3E31921BB909A7001E6788 /* EVObjectDescriptionTests.swift in Sources */,
-				7F3E318E1BB909A1001E6788 /* EVObject.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		2DC8AA5D1C24291800FA6B8E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 2DC8AA3C1C24215500FA6B8E /* EVReflection iOS */;
+			targetProxy = 2DC8AA5C1C24291800FA6B8E /* PBXContainerItemProxy */;
+		};
+		2DC8AA7B1C242E9100FA6B8E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 2DC8AA621C242E0600FA6B8E /* EVReflection OSX */;
+			targetProxy = 2DC8AA7A1C242E9100FA6B8E /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin XCBuildConfiguration section */
+		2DC8AA4E1C24215500FA6B8E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = EVReflection/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULE_NAME = EVReflection;
+				MODULE_VERSION = "";
+				PRODUCT_BUNDLE_IDENTIFIER = evermeer.EVReflectioniOS;
+				PRODUCT_NAME = EVReflection;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		2DC8AA4F1C24215500FA6B8E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = EVReflection/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULE_NAME = EVReflection;
+				MODULE_VERSION = "";
+				PRODUCT_BUNDLE_IDENTIFIER = evermeer.EVReflectioniOS;
+				PRODUCT_NAME = EVReflection;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		2DC8AA751C242E0600FA6B8E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = EVReflectionOSX/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MODULE_NAME = EVReflection;
+				PRODUCT_BUNDLE_IDENTIFIER = evermeer.EVReflectionOSX;
+				PRODUCT_NAME = EVReflection;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		2DC8AA761C242E0600FA6B8E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = EVReflectionOSX/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MODULE_NAME = EVReflection;
+				PRODUCT_BUNDLE_IDENTIFIER = evermeer.EVReflectionOSX;
+				PRODUCT_NAME = EVReflection;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 		7F07C57A1AF101A9000DF1F3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -341,7 +608,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -380,7 +647,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -391,10 +658,7 @@
 		7F07C5801AF101A9000DF1F3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -409,10 +673,7 @@
 		7F07C5811AF101A9000DF1F3 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "EVReflectionTests/ios-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "nl.evict.$(PRODUCT_NAME:rfc1034identifier)";
@@ -450,6 +711,22 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		2DC8AA521C24215500FA6B8E /* Build configuration list for PBXNativeTarget "EVReflection iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2DC8AA4E1C24215500FA6B8E /* Debug */,
+				2DC8AA4F1C24215500FA6B8E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		2DC8AA741C242E0600FA6B8E /* Build configuration list for PBXNativeTarget "EVReflection OSX" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2DC8AA751C242E0600FA6B8E /* Debug */,
+				2DC8AA761C242E0600FA6B8E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
 		7F07C5581AF101A9000DF1F3 /* Build configuration list for PBXProject "EVReflection" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/EVReflection/EVReflection.xcodeproj/xcshareddata/xcschemes/EVReflection OSX.xcscheme
+++ b/EVReflection/EVReflection.xcodeproj/xcshareddata/xcschemes/EVReflection OSX.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0720"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2DC8AA621C242E0600FA6B8E"
+               BuildableName = "EVReflection OSX.framework"
+               BlueprintName = "EVReflection OSX"
+               ReferencedContainer = "container:EVReflection.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7F3E31841BB9095C001E6788"
+               BuildableName = "EVReflection OSX Tests.xctest"
+               BlueprintName = "EVReflection OSX Tests"
+               ReferencedContainer = "container:EVReflection.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2DC8AA621C242E0600FA6B8E"
+            BuildableName = "EVReflection OSX.framework"
+            BlueprintName = "EVReflection OSX"
+            ReferencedContainer = "container:EVReflection.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2DC8AA621C242E0600FA6B8E"
+            BuildableName = "EVReflection OSX.framework"
+            BlueprintName = "EVReflection OSX"
+            ReferencedContainer = "container:EVReflection.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2DC8AA621C242E0600FA6B8E"
+            BuildableName = "EVReflection OSX.framework"
+            BlueprintName = "EVReflection OSX"
+            ReferencedContainer = "container:EVReflection.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/EVReflection/EVReflection.xcodeproj/xcshareddata/xcschemes/EVReflection iOS.xcscheme
+++ b/EVReflection/EVReflection.xcodeproj/xcshareddata/xcschemes/EVReflection iOS.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0720"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2DC8AA3C1C24215500FA6B8E"
+               BuildableName = "EVReflection iOS.framework"
+               BlueprintName = "EVReflection iOS"
+               ReferencedContainer = "container:EVReflection.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7F07C5711AF101A9000DF1F3"
+               BuildableName = "EVReflection iOS Tests.xctest"
+               BlueprintName = "EVReflection iOS Tests"
+               ReferencedContainer = "container:EVReflection.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2DC8AA3C1C24215500FA6B8E"
+            BuildableName = "EVReflection iOS.framework"
+            BlueprintName = "EVReflection iOS"
+            ReferencedContainer = "container:EVReflection.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2DC8AA3C1C24215500FA6B8E"
+            BuildableName = "EVReflection iOS.framework"
+            BlueprintName = "EVReflection iOS"
+            ReferencedContainer = "container:EVReflection.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2DC8AA3C1C24215500FA6B8E"
+            BuildableName = "EVReflection iOS.framework"
+            BlueprintName = "EVReflection iOS"
+            ReferencedContainer = "container:EVReflection.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/EVReflection/EVReflection/EVReflection.h
+++ b/EVReflection/EVReflection/EVReflection.h
@@ -1,0 +1,19 @@
+//
+//  EVReflection.h
+//  EVReflection
+//
+//  Created by Cotton, Jonathan (Mobile Developer) on 18/12/2015.
+//  Copyright © 2015 evict. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for EVReflection.
+FOUNDATION_EXPORT double EVReflectionVersionNumber;
+
+//! Project version string for EVReflection.
+FOUNDATION_EXPORT const unsigned char EVReflectionVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <EVReflection/PublicHeader.h>
+
+

--- a/EVReflection/EVReflection/Info.plist
+++ b/EVReflection/EVReflection/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/EVReflection/EVReflectionOSX/EVReflectionOSX.h
+++ b/EVReflection/EVReflectionOSX/EVReflectionOSX.h
@@ -1,0 +1,19 @@
+//
+//  EVReflectionOSX.h
+//  EVReflectionOSX
+//
+//  Created by Cotton, Jonathan (Mobile Developer) on 18/12/2015.
+//  Copyright © 2015 evict. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+//! Project version number for EVReflectionOSX.
+FOUNDATION_EXPORT double EVReflectionOSXVersionNumber;
+
+//! Project version string for EVReflectionOSX.
+FOUNDATION_EXPORT const unsigned char EVReflectionOSXVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <EVReflectionOSX/PublicHeader.h>
+
+

--- a/EVReflection/EVReflectionOSX/Info.plist
+++ b/EVReflection/EVReflectionOSX/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2015 evict. All rights reserved.</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/EVReflection/EVReflectionTests/EVObjectDescriptionTests.swift
+++ b/EVReflection/EVReflectionTests/EVObjectDescriptionTests.swift
@@ -6,6 +6,7 @@
 //
 
 import XCTest
+@testable import EVReflection
 
 /**
 Testing EVObjectDescription

--- a/EVReflection/EVReflectionTests/EVReflectionAssociatedTests.swift
+++ b/EVReflection/EVReflectionTests/EVReflectionAssociatedTests.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+@testable import EVReflection
 
 
 import XCTest

--- a/EVReflection/EVReflectionTests/EVReflectionEVObjectTests.swift
+++ b/EVReflection/EVReflectionTests/EVReflectionEVObjectTests.swift
@@ -8,6 +8,7 @@
 
 
 import XCTest
+@testable import EVReflection
 
 /**
  Testing EVReflection

--- a/EVReflection/EVReflectionTests/EVReflectionJsonTests.swift
+++ b/EVReflection/EVReflectionTests/EVReflectionJsonTests.swift
@@ -6,6 +6,7 @@
 //
 
 import XCTest
+@testable import EVReflection
 
 class User: EVObject {
     var id: Int = 0

--- a/EVReflection/EVReflectionTests/EVReflectionMappingTest.swift
+++ b/EVReflection/EVReflectionTests/EVReflectionMappingTest.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2015 evict. All rights reserved.
 //
 import XCTest
+@testable import EVReflection
 
 /**
  Testing EVReflection

--- a/EVReflection/EVReflectionTests/EVReflectionNumbersTests.swift
+++ b/EVReflection/EVReflectionTests/EVReflectionNumbersTests.swift
@@ -8,6 +8,7 @@
 
 
 import XCTest
+@testable import EVReflection
 
 /**
  Testing EVReflection

--- a/EVReflection/EVReflectionTests/EVReflectionPropertyMappingTest.swift
+++ b/EVReflection/EVReflectionTests/EVReflectionPropertyMappingTest.swift
@@ -8,6 +8,7 @@
 
 
 import XCTest
+@testable import EVReflection
 
 /**
  Testing EVReflection

--- a/EVReflection/EVReflectionTests/EVReflectionTests.swift
+++ b/EVReflection/EVReflectionTests/EVReflectionTests.swift
@@ -6,6 +6,7 @@
 //
 
 import XCTest
+@testable import EVReflection
 
 /**
 Testing EVReflection

--- a/EVReflection/EVReflectionTests/EVReflectionWorkaroundSwiftGenericsTests.swift
+++ b/EVReflection/EVReflectionTests/EVReflectionWorkaroundSwiftGenericsTests.swift
@@ -6,6 +6,7 @@
 //
 
 import XCTest
+@testable import EVReflection
 
 
 /**

--- a/EVReflection/EVReflectionTests/EVReflectionWorkaroundsTests.swift
+++ b/EVReflection/EVReflectionTests/EVReflectionWorkaroundsTests.swift
@@ -6,6 +6,7 @@
 //
 
 import XCTest
+@testable import EVReflection
 
 
 /**

--- a/EVReflection/EVReflectionTests/EVRelfectionEnheritanceTests.swift
+++ b/EVReflection/EVReflectionTests/EVRelfectionEnheritanceTests.swift
@@ -8,6 +8,7 @@
 
 
 import XCTest
+@testable import EVReflection
 
 
 /**

--- a/EVReflection/EVReflectionTests/ProfilePhotoUrlListTest.swift
+++ b/EVReflection/EVReflectionTests/ProfilePhotoUrlListTest.swift
@@ -6,6 +6,7 @@
 //
 
 import XCTest
+@testable import EVReflection
 
 /**
 Testing EVReflection for Json

--- a/EVReflection/EVReflectionTests/TestObjects.swift
+++ b/EVReflection/EVReflectionTests/TestObjects.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+@testable import EVReflection
 
 /**
 First test object where the base class is just an NSObject

--- a/EVReflection/EVReflectionTests/WorkaroundEnumTest.swift
+++ b/EVReflection/EVReflectionTests/WorkaroundEnumTest.swift
@@ -6,6 +6,7 @@
 //
 
 import XCTest
+@testable import EVReflection
 
 
 class myClass: NSObject {

--- a/EVReflection/pod/EVReflection.swift
+++ b/EVReflection/pod/EVReflection.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+
 /**
  Reflection methods
  */


### PR DESCRIPTION
This may well not be the best approach for this, but had a go at splitting down the project into an iOS framework and an OSX framework, I left the project layout mostly intact, so as not to intefere with cocoapods compatibility.
