### PR TITLE
Make property converters optional

### DIFF
--- a/EVReflection/EVReflectionTests/EVReflectionMappingTest.swift
+++ b/EVReflection/EVReflectionTests/EVReflectionMappingTest.swift
@@ -72,7 +72,7 @@ public class GameAdministrator: GameUser {
         return [("level","rating")]
     }
 
-    override public func propertyConverters() -> [(String?, (Any?)->(), () -> Any? )] {
+    override public func propertyConverters() -> [(String?, ((Any?)->())?, (() -> Any?)? )] {
         return [
             ( // We want a custom converter for the field isGreat
                 "level"

--- a/EVReflection/EVReflectionTests/EVReflectionSyncAlternateDesync.swift
+++ b/EVReflection/EVReflectionTests/EVReflectionSyncAlternateDesync.swift
@@ -63,7 +63,7 @@ class z: EVObject {
     var bar: String? = "bar"
     var arr: [y] = []
     
-    override func propertyConverters() -> [(String?, (Any?) -> (), () -> Any?)] {
+    override func propertyConverters() -> [(String?, ((Any?) -> ())?, (() -> Any?)?)] {
         return [
             ( "arr",
                 { self.arr = $0 as! [y] },

--- a/EVReflection/EVReflectionTests/EVReflectionTests.swift
+++ b/EVReflection/EVReflectionTests/EVReflectionTests.swift
@@ -237,7 +237,7 @@ class EVReflectionTests: XCTestCase {
         print("json = \(json)")
     }
     
-    func testNilDeserializer() {
+    func testNilPropertyGetter() {
         
         let theObject = TestObjectWithNilConverters()
         theObject.optionalValue = "123"
@@ -248,7 +248,7 @@ class EVReflectionTests: XCTestCase {
         XCTAssertNil(optionalValue)
     }
     
-    func testNilSerializer() {
+    func testNilPropertySetter() {
         
         let json = "{\"optionalValue\": \"123\"}"
         

--- a/EVReflection/EVReflectionTests/EVReflectionTests.swift
+++ b/EVReflection/EVReflectionTests/EVReflectionTests.swift
@@ -31,7 +31,7 @@ class EVReflectionTests: XCTestCase {
     }
 
     /**
-    Get the string name for a clase and then generate a class based on that string
+    Get the string name for a class and then generate a class based on that string
     */
     func testClassToAndFromString() {
         // Test the EVReflection class - to and from string
@@ -235,6 +235,26 @@ class EVReflectionTests: XCTestCase {
     func testDictionary() {
         let json = DicTest().toJsonString()
         print("json = \(json)")
+    }
+    
+    func testNilDeserializer() {
+        
+        let theObject = TestObjectWithNilConverters()
+        theObject.optionalValue = "123"
+
+        let json = theObject.toDictionary()
+        
+        let optionalValue = json["optionalValue"]
+        XCTAssertNil(optionalValue)
+    }
+    
+    func testNilSerializer() {
+        
+        let json = "{\"optionalValue\": \"123\"}"
+        
+        let theObject = TestObjectWithNilConverters(json: json)
+        
+        XCTAssertNil(theObject.optionalValue)
     }
 }
 

--- a/EVReflection/EVReflectionTests/TestObjects.swift
+++ b/EVReflection/EVReflectionTests/TestObjects.swift
@@ -116,7 +116,7 @@ For testing the custom property conversion
 public class TestObject6: EVObject {
     var isGreat: Bool = false
     
-    override public func propertyConverters() -> [(String?, (Any?)->(), () -> Any? )] {
+    override public func propertyConverters() -> [(String?, ((Any?)->())?, (() -> Any?)? )] {
         return [
             ( // We want a custom converter for the field isGreat
               "isGreat"
@@ -163,3 +163,13 @@ public class TestObject7: EVObject {
     var subOne: SubObject?
     var subTwo: SubObject?
 }
+
+public class TestObjectWithNilConverters: EVObject {
+    
+    var optionalValue: String?
+    
+    override public func propertyConverters() -> [(String?, ((Any?)->())?, (() -> Any?)? )] {
+        return [("optionalValue", nil, nil)]
+    }
+}
+

--- a/EVReflection/pod/EVObject.swift
+++ b/EVReflection/pod/EVObject.swift
@@ -206,7 +206,7 @@ public class EVObject: NSObject, NSCoding { // These are redundant in Swift 2+: 
     
     This method is in EVObject and not in extension of NSObject because a functions from extensions cannot be overwritten yet
     
-    :returns: Return an array with valupairs of the object property name and json key name.
+    :returns: Return an array with value pairs of the object property name and json key name.
     */
     public func propertyMapping() -> [(String?, String?)] {
         return []
@@ -219,7 +219,7 @@ public class EVObject: NSObject, NSCoding { // These are redundant in Swift 2+: 
     
     :returns: Returns an array where each item is a combination of the folowing 3 values: A string for the property name where the custom conversion is for, a setter function and a getter function.
     */
-    public func propertyConverters() -> [(String?, (Any?)->(), () -> Any? )] {
+    public func propertyConverters() -> [(String?, ((Any?)->())?, (() -> Any?)? )] {
         return []
     }
 

--- a/EVReflection/pod/EVReflection.swift
+++ b/EVReflection/pod/EVReflection.swift
@@ -869,7 +869,7 @@ final public class EVReflection {
                     if let (_, _, propertyGetter) = (theObject as? EVObject)?.propertyConverters().filter({$0.0 == originalKey}).first {
                         
                         guard let propertyGetter = propertyGetter else {
-                            continue    // if propertyGetter is nil, skip deserializing it
+                            continue    // if propertyGetter is nil, skip getting the property
                         }
                         
                         value = propertyGetter()

--- a/EVReflection/pod/EVReflection.swift
+++ b/EVReflection/pod/EVReflection.swift
@@ -590,6 +590,11 @@ final public class EVReflection {
             //            }
         } else {
             if let (_, propertySetter, _) = (anyObject as? EVObject)?.propertyConverters().filter({$0.0 == key}).first {
+                
+                guard let propertySetter = propertySetter else {
+                    return  // if the propertySetter is nil, skip setting the property
+                }
+                
                 propertySetter(value)
                 return
             }            
@@ -862,7 +867,13 @@ final public class EVReflection {
 
                     // If there is a properyConverter, then use the result of that instead.
                     if let (_, _, propertyGetter) = (theObject as? EVObject)?.propertyConverters().filter({$0.0 == originalKey}).first {
+                        
+                        guard let propertyGetter = propertyGetter else {
+                            continue    // if propertyGetter is nil, skip deserializing it
+                        }
+                        
                         value = propertyGetter()
+                        
                         let (unboxedValue2, _, _) = valueForAny(theObject, key: originalKey, anyValue: value)
                         unboxedValue = unboxedValue2
                     }


### PR DESCRIPTION
This PR makes property converters optional.

In the event that a setter/getter converter is `nil`, the property deserialization/serialization will be skipped.

This resolves issue #54.
