### PR TITLE
Bug with NSCoding and custom array

### DIFF
--- a/EVReflection/EVReflectionTests/EVReflectionEVObjectTests.swift
+++ b/EVReflection/EVReflectionTests/EVReflectionEVObjectTests.swift
@@ -153,5 +153,32 @@ class EVReflectionEVObjectTests: XCTestCase {
         // Test if the objects are the same
         XCTAssert(theObject == result, "Pass")
     }
+    
+    /**
+    */
+    func testNSCodingSubObjectArray() {
+        let rootObject = TestRootObject()
+        rootObject.id = "root"
+        let inner1 = TestInnerObject()
+        inner1.id = "inner1"
+        let inner2 = TestInnerObject()
+        inner1.id = "inner2"
+        rootObject.array = [inner1, inner2]
+        
+        let filePath = (NSTemporaryDirectory() as NSString).stringByAppendingPathComponent("rootObject.dat")
+        
+        // Write object to file
+        NSKeyedArchiver.archiveRootObject(rootObject, toFile: filePath)
+        
+        // Read object from file
+        let result = NSKeyedUnarchiver.unarchiveObjectWithFile(filePath) as? TestRootObject
+        
+        XCTAssert(result!.array!.count == 2, "Array size should be 2")
+        
+        //Crash here
+        let out1 = result!.array?.first
+    
+        XCTAssert(out1!.id == "inner1")
+    }
 
 }

--- a/EVReflection/EVReflectionTests/TestObjects.swift
+++ b/EVReflection/EVReflectionTests/TestObjects.swift
@@ -186,3 +186,15 @@ public class AA : EVObject{
 public class BB : EVObject{
     public var val : Int = 0
 }
+
+public class TestBaseObject: EVObject {
+    var id: String?
+}
+
+public class TestRootObject: TestBaseObject {
+    var array: [TestInnerObject]?
+}
+
+public class TestInnerObject: TestBaseObject {
+
+}


### PR DESCRIPTION
I wrote a simple test to demonstrate a bug I encounter into my app. 

I use a base class and I have a class that hold an array of custom objects. Parsing is fine, but when I archive it and then unarchive it, the object in the custom array is casted as an NSDictionary and not as object of my class type. In this test it crash earlier than that thought. Am I doing something wrong or is it unsupported at this point ?

The crash is `fatal error: NSArray element failed to match the Swift Array Element type`
