### PR TITLE
Fix blind mapping to values without considering type

### DIFF
--- a/EVReflection/EVReflectionTests/EVReflectionMappingTest.swift
+++ b/EVReflection/EVReflectionTests/EVReflectionMappingTest.swift
@@ -47,10 +47,25 @@ class EVReflectionMappingTests: XCTestCase {
         NSLog("player = \(player)")
         NSLog("administrator = \(administrator)")
 
-        XCTAssertEqual(administrator.name, player.name, "The names will be the same")
-        XCTAssertEqual(administrator.memberSince, player.memberSince, "The member since dates will be the same")
-        XCTAssertEqual(administrator.level, 19, "When creatinga an administrator it's level will be a quarter of the player rating")
+        XCTAssertEqual(administrator.name, player.name, "The names should be the same")
+        XCTAssertEqual(administrator.memberSince, player.memberSince, "The member since dates should be the same.")
+        XCTAssertEqual(administrator.level, 19, "When creatinga an administrator, it's level should be a quarter of the player's rating")
+    }
+    
+    func testNonmatchingPropertyTypeInDictionarySilentlySkipsPropertySettingWithoutThrowingAnError() {
         
+        let name = "Me"
+        let gamesPlayed = 42
+        
+        let json = "{ \"name\": \"\(name)\", \"memberSince\": \"\", \"gamesPlayed\": \(gamesPlayed)," +
+                      "\"rating\": {\"score\": 111, \"rank\": 122 } }"
+        
+        let player = GamePlayer(json: json)
+        XCTAssertEqual(player.name, name)
+        XCTAssertEqual(player.gamesPlayed, gamesPlayed)
+        
+        XCTAssertNil(player.memberSince)
+        XCTAssertEqual(player.rating, 0)
     }
 }
 

--- a/EVReflection/pod/EVExtensions.swift
+++ b/EVReflection/pod/EVExtensions.swift
@@ -98,3 +98,31 @@ public extension Array {
     }
     
 }
+
+public  extension NSObject {
+    
+
+    func getTypeForPropertyName(propertyName: String) -> Any.Type? {
+        
+        let mirror = Mirror(reflecting: self)
+        return getTypeForPropertyName(propertyName, mirror: mirror)
+    }
+    
+    func getTypeForPropertyName(propertyName: String, mirror: Mirror) -> Any.Type? {
+        
+        for (label, value) in mirror.children {
+            if propertyName == label {
+                return Mirror(reflecting: value).subjectType
+            }
+        }
+        
+        guard let superclassMirror = mirror.superclassMirror() else {
+            return nil
+        }
+        
+        return getTypeForPropertyName(propertyName, mirror: superclassMirror)        
+    }
+
+    
+    
+}

--- a/EVReflection/pod/EVExtensions.swift
+++ b/EVReflection/pod/EVExtensions.swift
@@ -102,13 +102,20 @@ public extension Array {
 public  extension NSObject {
     
 
-    func getTypeForPropertyName(propertyName: String) -> Any.Type? {
+    /**
+     Get the type for a given property name or `nil` if there aren't any properties matching said name.
+     
+     - parameter propertyName: The property name
+     
+     - returns: The type for the property
+     */
+    public func getTypeForPropertyName(propertyName: String) -> Any.Type? {
         
         let mirror = Mirror(reflecting: self)
         return getTypeForPropertyName(propertyName, mirror: mirror)
     }
     
-    func getTypeForPropertyName(propertyName: String, mirror: Mirror) -> Any.Type? {
+    private func getTypeForPropertyName(propertyName: String, mirror: Mirror) -> Any.Type? {
         
         for (label, value) in mirror.children {
             if propertyName == label {


### PR DESCRIPTION
@evermeer 

We ran into an issue where our JSON data source didn't match our app's model properties. Consequently, EVReflection crashed the app...!

I found this was due to "blindly mapping" property values via `setValue(_:, forKey:)` without first considering the property type.

This is an initial attempt to fix this issue.

All of the unit tests pass, but we're likely missing tests.

I'm pretty sure the changes here will prevent calling `setValue(_:, forUndefinedKey)`, which some existing users may rely on...?

However, a crash is a big concern, so I wanted to put this out there, request that you review it, and see if you had any ideas to close the gap here.

Thanks! ;)
