### PR TITLE
Remove final attributes from EVObject's toDictionary(:) and toJsonString(:) methods

### DIFF
--- a/EVReflection/pod/EVObject.swift
+++ b/EVReflection/pod/EVObject.swift
@@ -246,7 +246,7 @@ public class EVObject: NSObject, NSCoding { // These are redundant in Swift 2+: 
     
     :returns: The dictionary
     */
-    final public func toDictionary(performKeyCleanup:Bool = false) -> NSDictionary {
+    public func toDictionary(performKeyCleanup:Bool = false) -> NSDictionary {
         let (reflected, _) = EVReflection.toDictionary(self, performKeyCleanup: performKeyCleanup)
         return reflected
     }
@@ -258,7 +258,7 @@ public class EVObject: NSObject, NSCoding { // These are redundant in Swift 2+: 
      
      :returns: The json string
      */
-    final public func toJsonString(performKeyCleanup:Bool = false) -> String {
+    public func toJsonString(performKeyCleanup:Bool = false) -> String {
         return EVReflection.toJsonString(self, performKeyCleanup: performKeyCleanup)
     }
     


### PR DESCRIPTION
This PR removes the `final` attributes from `EVObject`'s `toDictionary(:)` and `toJsonString(:)` methods.

This way, subclasses can override these methods. Thereby, memory- or performance-concerned consumers (e.g. in cases where _many_ objects of a certain type are created) can create their own implementations for serializing certain objects.

This also provides a possible workaround for issue #60 .
