### PR TITLE
don't use dictionaryAndArrayConversion if a PropertyConverter exist

### DIFF
--- a/Source/EVReflection.swift
+++ b/Source/EVReflection.swift
@@ -80,9 +80,17 @@ final public class EVReflection {
                 let useKey: String = (mapping ?? objectKey) as? String ?? ""
                 let original: Any? = getValue(anyObject, key: useKey)
                 let dictKey: String = cleanupKey(anyObject, key: objectKey, tryMatch: types) ?? ""
-                let (dictValue, valid) = dictionaryAndArrayConversion(anyObject, key: objectKey, fieldType: types[dictKey] as? String ?? types[useKey] as? String, original: original, theDictValue: v as Any?, conversionOptions: conversionOptions)
-                if dictValue != nil {
-                    let value: Any? = valid ? dictValue : (v as Any)
+                let valid : Bool
+                let dictValue : Any?
+                
+                if conversionOptions.contains(.PropertyConverter) && (anyObject as! EVReflectable).propertyConverters().filter({$0.0 == useKey}).first != nil {
+                    valid = false
+                    dictValue = nil
+                } else {
+                    (dictValue, valid) = dictionaryAndArrayConversion(anyObject, key: objectKey, fieldType: types[dictKey] as? String ?? types[useKey] as? String, original: original, theDictValue: v as Any?, conversionOptions: conversionOptions)
+                }
+                
+                if let value: Any = valid ? dictValue : (v as Any) {
                     if let custom = original as? EVCustomReflectable {
                         custom.constructWith(value: value)
                     }


### PR DESCRIPTION
If a property converter exist for the useKey then don't use the dictionaryAndArrayConversion.

If you have a code like the one below and the dictionaryAndArrayConversion is call first when the propertyConverters method is call the value ($0) is already the Forecast object. 
If you want to do some custom converter then it should call the property converter for the useKey with the JSON dictionary.

```
class WeatherResponse: EVNetworkingObject {
    var location: String?
    var three_day_forecast: [Forecast] = [Forecast]()

 override func propertyConverters() -> [(key: String, decodeConverter: ((Any?) -> ()), encodeConverter: (() -> Any?))] {
    return [
            ( // We want a custom converter for the field three_day_forecast
              key: "three_day_forecast"
              // three_day_forecast will be a Array of dictionaries
              , decodeConverter: { 
                      guard let value = $0 as? NSArray else {
                            return
                    }
                    
                    self.three_day_forecast = value.map { Forecast(dictionary:$0) }
              }
              , encodeConverter: { return self.three_day_forecast.toDictionary() })
        ]
    }
}

class Forecast: EVNetworkingObject {
    var day: String?
    var temperature: NSNumber?
    var conditions: String?
}

```