### PR TITLE
Fix crash and show warning if Realm Object is not key value coding-co…

### DIFF
--- a/Source/Realm/RealmListEVCustomReflectable.swift
+++ b/Source/Realm/RealmListEVCustomReflectable.swift
@@ -31,3 +31,12 @@ extension List : EVCustomReflectable {
         //return self.enumerated().map { ($0.element as? EVReflectable)?.toDictionary() ?? NSDictionary() }
     }
 }
+
+extension Object : EVReflectable {
+    
+    open override func setValue(_ value: Any?, forUndefinedKey key: String) {
+        self.addStatusMessage(.IncorrectKey, message: "The class '\(EVReflection.swiftStringFromClass(self))' is not key value coding-compliant for the key '\(key)'")
+        
+        evPrint(.IncorrectKey, "\nWARNING: The class '\(EVReflection.swiftStringFromClass(self))' is not key value coding-compliant for the key '\(key)'\n")
+    }
+}


### PR DESCRIPTION
Currently the app crashes when Realm Objects differ from the source JSON, and it's not very clear how to address this issue. 

