### PR TITLE
Typo? breaks world wide development with your Kit

### DIFF
--- a/EVReflection.podspec
+++ b/EVReflection.podspec
@@ -18,7 +18,7 @@ EOS
   s.tvos.deployment_target = '9.0'
 
   s.pod_target_xcconfig = { 'SWIFT_VERSION' => '4.2' }
-  s.swift_versions = ['4.0', '4.2', '5.0']
+  s.swift_version = ['4.0', '4.2', '5.0']
 
   s.source       = { :git => "https://github.com/evermeer/EVReflection.git", :tag => s.version }
   s.default_subspec = "Core"


### PR DESCRIPTION
Pre-downloading: `EVReflection` from `https://github.com/evermeer/EVReflection.git`, branch `master`
[!] Failed to load 'EVReflection' podspec: 
[!] Invalid `EVReflection.podspec` file: undefined method `swift_versions=' for #<Pod::Specification name="EVReflection">
Did you mean?  swift_version=
               swift_version.

 #  from /var/folders/04/q7ff1yjx16lckz30k_z0fsp80000gn/T/d20190328-27539-111ptkx/EVReflection.podspec:21
 #  -------------------------------------------
 #    s.pod_target_xcconfig = { 'SWIFT_VERSION' => '4.2' }
 >    s.swift_versions = ['4.0', '4.2', '5.0']
 #  
 #  -------------------------------------------